### PR TITLE
alternative color scheme

### DIFF
--- a/sass/_typography.scss
+++ b/sass/_typography.scss
@@ -1,17 +1,28 @@
+/* font stacks */
+$body_font: "Droid Serif", Georgia, serif;
+$title_font: "M+2pheavy", "Helvetica Neue", Arial, Helvetica, sans-serif;
+$clean_font: "Helvetica Neue", Arial, Helvetica, sans-serif;
+$code_font: "DejaVu Sans Mono", Inconsolata, Consolas, "Lucida Console", monospace;
+
+$color_base: #CC211B;
+
 @font-face {
 	font-family: 'M+2pheavy';
-	src: url('/fonts/mplus-2p-heavy-webfont.eot#') format('eot'), 
-	     url('/fonts/mplus-2p-heavy-webfont.woff') format('woff'), 
+	src: url('/fonts/mplus-2p-heavy-webfont.eot');
+	src: url('/fonts/mplus-2p-heavy-webfont.eot?') format('☺'),
+	     url('/fonts/mplus-2p-heavy-webfont.woff') format('woff'),
 	     url('/fonts/mplus-2p-heavy-webfont.ttf') format('truetype'),
 	     url('/fonts/mplus-2p-heavy-webfont.svg#mplus2pheavy') format('svg');
   font-weight: bold;
   font-style: normal;
 }
 
-body { font-size: 14px; line-height: 1.45em; font-family: "Droid Serif"; }
-
+body { font-size: 14px; line-height: 1.45em; font-family: $body_font; }
 h1 { font-size: 300%; }
 h2 { font-size: 160%; }
 h3 { font-size: 140%; }
-h4 { font-size: 120%; }
-/* h5, h6 are 100% */
+h4, h5 { font-size: 120%; }
+h6 { font-size: 100%; }
+h5, h6 { font-family: $clean_font; }
+h4, h6 { font-weight: bold; }
+h4, h5, h6 { color: darken($color_base, 30%); }

--- a/sass/all.scss
+++ b/sass/all.scss
@@ -23,14 +23,14 @@ p.pubdate { display: none; }
 header.head {
 	div.logo {
 		@include border-radius(0.3em);
-		font-size: 10px; background-color: $color_base; color: #fff; padding: 2.5em 0.7em 0.25em; font-family: Arial, Helvetica, sans-serif; text-align: center; letter-spacing: 0.1em;
+		font-size: 10px; background-color: $color_base; color: #fff; padding: 2.5em 0.7em 0.25em; font-family: $clean_font; text-align: center; letter-spacing: 0.1em;
 	}
 	
-	h1 { line-height: 1em; font-family: "M+2pheavy"; font-weight: bold; color: black; }
+	h1 { line-height: 1em; font-family: $title_font; font-weight: bold; color: black; }
   h1 a { color: black; }
   h1 a:link, h1 a:visited {border-bottom: 0;}
   h1 a:hover { text-shadow: 0 0 5px rgba(0,0,0,.6); }
-	h2 { font-size: 12px; margin-bottom: 0.5em; font-family: "Droid Serif"; font-style: italic; font-weight: normal; color: #666; }
+	h2 { font-size: 12px; margin-bottom: 0.5em; font-family: $body_font; font-style: italic; font-weight: normal; color: #666; }
 	
 	div#search {
 		ol:empty { border: 0; }
@@ -53,14 +53,14 @@ section[role="main"] {
 }
 
 section[role="main"] > h2 {
-	position: relative; text-transform: uppercase; letter-spacing: 0.2em; line-height: 1.5em; font-family: "M+2pheavy"; margin: 2em 0;
+	position: relative; text-transform: uppercase; letter-spacing: 0.2em; line-height: 1.5em; font-family: $title_font; margin: 2em 0;
 	.secno { position: absolute; display: block; left: -1.5em; text-align: right;  }	
 }
 
 a.secno, h3 .secno, h4 .secno, h5 .secno, h6 .secno { display: none; } /* Only top level section numbering */
 
 h3, h4, h5, h6 { margin: 3em 0 1em 0; }
-h4, h5, h6 {color: #4c0c0a;}
+h4, h5, h6 { color: darken($color_base, 30%); }
 
 section#credits {
 	margin-top: 3em;
@@ -72,7 +72,7 @@ p { margin-bottom: 1em; }
 ul, ol, dl { margin-bottom: 1em; }
 ul li { list-style: none; /*margin-bottom: 0.25em;*/ }
 
-ul li:before { content: '\22c5'; font-size: 2em; color: #CCC; margin-left: -0.65em; font-family: Arial; font-weight: bold; }
+ul li:before { content: '\22c5'; font-size: 2em; color: #CCC; margin-left: -0.65em; font-family: $clean_font; font-weight: bold; }
 
 ul li ul { margin: 0em; }
 li li { margin-left: 1.2em; }
@@ -81,7 +81,7 @@ li li { margin-left: 1.2em; }
 ul.domTree li { margin-bottom: 0; }
 ul.domTree li:before { display: none; }
 
-code, pre { font-family: "Bitstream Vera Sans Mono", "DejaVu Sans Mono", "Andale Mono", Inconsolata, "Lucida Console", Consolas, Monaco, "courier new", courier; display: inline-block; font-style: normal; }
+code, pre { font-family: $code_font; display: inline-block; font-style: normal; }
 
 pre { 
 	display: block; padding: 0.25em 0.3em; border: 1px solid #eee;
@@ -107,7 +107,7 @@ dd { margin-bottom: 0.5em; }
 table { border: 0; }
 table th, table td { border: 0; border-bottom: 1px solid #acc; padding: 4px; vertical-align: top; }
 table th li, table td li { margin: 0 0 0 1.5em; }
-table caption, table th { text-align: left; color: #4c0c0a; }
+table caption, table th { text-align: left; color: darken($color_base, 30%); }
 table th { font-weight: bold; }
 table td { vertical-align: top; padding: 0.25em 1.25em 0.25em 0em; }
 table tr, table tbody { border: 0px; }
@@ -133,7 +133,7 @@ strong.rfc2119 { font-size: 0.8em; letter-spacing: 0.1; text-transform: uppercas
 	Typographic conventions
 	(http://developers.whatwg.org/introduction.html#typographic-conventions)
 */
-.note { padding: 10px; background-color: #eee; }
+.note { padding: 3px; background-color: #eee; }
 .example { color: #666; font-style: italic; }
 .XXX { background-color: lighten($color_base, 50%); padding: 0.5em; } /* An open issue */
 .warning { background-color: lighten($color_base, 40%); border: 1px solid $color_base; padding: 0.5em; }
@@ -145,7 +145,7 @@ strong.rfc2119 { font-size: 0.8em; letter-spacing: 0.1; text-transform: uppercas
 div#up-next {
   @include box-shadow(2px, 2px, 3px, rgba(0, 0, 0, 0.4)); 
 	
-	margin-top: 3em; padding: 0.7em 1em; background-color: #4c0c0a;
+	margin-top: 3em; padding: 0.7em 1em; background-color: darken($color_base, 30%);
   p { font-style: italic; font-size: 0.7em; margin: 0; color: white; }
   h1 { font-weight: bold; font-size: 16px; margin: 0; color: white; }
   h1:after{ content: "—"; }

--- a/sass/handheld.scss
+++ b/sass/handheld.scss
@@ -17,7 +17,7 @@ nav, nav ol li { text-align: center; }
 nav ol { list-style: none; }
 
 nav > ol:before { 
-	content: "— On this page —"; font-family: "M+2pheavy"; font-size: 14px; display: block; text-transform: uppercase; letter-spacing: 0.1em; margin-bottom: 0.75em;
+	content: "— On this page —"; font-family: $title_font; font-size: 14px; display: block; text-transform: uppercase; letter-spacing: 0.1em; margin-bottom: 0.75em;
 }
 nav ol li span { display: none; }
 nav ol li a { font-size: 14px; line-height: 1.1em; }


### PR DESCRIPTION
hey homies, finally getting into it.

The issues I have with the red color scheme are:
- red is a k.o. color, but the spec has a ton of links
- there’s no differentiation between links and other uses of red, e.g. h4-h6, table captions, table th
- there are no visited or active link styles

I figure that we keep red as the branding and action (eg :active) color, and use it sparingly. That means we need another set of link colors. I’ve based the links on #055799 blue (triad color with #CC211B), and also used #4c0c0a (darker monochrome of #CC211B). Dunno if you’ll like it, but we definitely need to address the stuff listed above somehow
