### PR TITLE
Improved bullets

### DIFF
--- a/sass/all.scss
+++ b/sass/all.scss
@@ -72,7 +72,7 @@ p { margin-bottom: 1em; }
 ul, ol, dl { margin-bottom: 1em; }
 ul li { list-style: none; /*margin-bottom: 0.25em;*/ }
 
-ul li:before { content: '\22c5'; font-size: 2em; vertical-align: middle; color: $neutral_color; margin-left: -0.65em; font-family: $clean_font; font-weight: bold; } /* todo: why not middot? */
+ul li:before { content:'\00b7'; font-size:1.5em; float:left; text-align:center; position:relative; left:-0.6em; top:-0.3em; margin-right:-0.6em; line-height:1.45em; width:0.6em; color:$neutral_color; font-family:$clean_font; font-weight:bold; }
 
 ul li ul { margin: 0em; }
 li li { margin-left: 1.2em; }


### PR DESCRIPTION
Noticed the unordered list bullets look funny in Firefox (previously: http://localhostr.com/files/iPFNgzd/before+in+firefox.png) so I poked around and improved the bullet rendering. 

Notice also that before the first line was farther to the left than the second line of a list item. I tried to keep within the designer's intent. Note that this still does not look great in IE8 though it is passable. Not sure how much can be done on that front if you want to use `:before` to render the bullet.

Here's an after shot: http://localhostr.com/files/FXQQ9bN/after+in+firefox.png

P.S. I switched to middledot per your Todo which worked out well.
