### PR TITLE
Fix for bug #47, overlapping subtopic numbers (e.g. 4.12) in index table of contents

### DIFF
--- a/sass/all.scss
+++ b/sass/all.scss
@@ -124,7 +124,8 @@ hr { display: none; }
 section[role="main"] > ol.toc {
 	display: block;
 	li { position: relative; list-style: none; }
-	li span { margin-left: -1.5em; position: absolute; }
+	li span { left: -1.5em; position: absolute; }
+	li li span { left: -1.4em; }
 	li ol ol { display: none; }
 	li li { margin-left: 1.4em; }
 	li li a { margin-left: 1em; }


### PR DESCRIPTION
Tested Safari, FF 3.6, IE7. This was previously broken in IE as well.
