### PR TITLE
Don't stretch narrow images in handheld view

### DIFF
--- a/sass/handheld.scss
+++ b/sass/handheld.scss
@@ -44,7 +44,7 @@ div.reference-wrapper {
 section[role="main"] { 
 	padding: 0 2em; font-size: 110%; line-height: 1.6em;
 	
-	img { width: 100%; }
+	img { max-width: 100%; height: auto; }
 	& > h2 { font-size: 18px; }
 }
 


### PR DESCRIPTION
If the handheld CSS has been selected then setting images to be full-width
was stretching narrow images (but leaving their height alone), distorting
them. For example see the sample rendering images in this section:
http://developers.whatwg.org/states-of-the-type-attribute.html#range-state-%28type=range%29

This can be seen in a desktop browser simply by resizing the window to under 960px.

Fix the problem by not resizing images that already fit.

Instead, set a maximum width so that large images get scaled down to fit,
and ensure the height stays in proportion with the width.
